### PR TITLE
Now subscription is done at the earliest possible moment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "react-extended-state",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-extended-state",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "A simple react provider and hook implementation to allow for state management",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/ExtendedStateManager/ExtendedStateManager.ts
+++ b/src/ExtendedStateManager/ExtendedStateManager.ts
@@ -41,7 +41,7 @@ export const areResultsEqual = <S>(previous: S, current: S, filter: Filter<S>): 
 
 export class ExtendedStateManager<S extends PossibleExtendedState> {
     private state: S;
-    private subscribers: Set<Subscriber>;
+    private readonly subscribers: Set<Subscriber>;
 
     constructor(initialState: S) {
         this.state = initialState;

--- a/src/react/ExtendedState.tsx
+++ b/src/react/ExtendedState.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, FC, useContext, useEffect, useMemo, useState } from 'react';
+import React, { createContext, FC, useContext, useLayoutEffect, useMemo, useState } from 'react';
 
 import { ExtendedStateManager, areResultsEqual, Filter, PossibleExtendedState } from '../ExtendedStateManager';
 import { CapturePoint, throwCaptured } from '../utils';
@@ -73,7 +73,11 @@ export const createExtendedState = <S extends PossibleExtendedState>(): Extended
          */
         const [currentResult, setResult] = useState(() => selector(manager.getState()));
 
-        useEffect(
+        /**
+         * Use layout is here so subscription (and further changes)
+         * Are done at the first possible moment
+         */
+        useLayoutEffect(
             () =>
                 manager.subscribe(
                     (previousState, currentState) => {


### PR DESCRIPTION
Fixing issues with changes in state before the end of rendering
This could cause the wrong evaluated state hook
Mostly useful for tests that depend on this lib